### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 
 Usage
 -----
-The methods provided in RestForIOS.h can be used to construct a wrapper class for the RESTful API you wish to access. All methods are fully documented in RestForIOS.h, and are appledoc'd (so the documentation shows up in XCode).
+The methods provided in RestForIOS.h can be used to construct a wrapper class for the RESTful API you wish to access. All methods are fully documented in RestForIOS.h, and are appledoc'd (so the documentation shows up in Xcode).
 
 All the methods in RestForIOS are class methods (+), so if you have a functional bent to your programming style, RestForIOS is a good fit. I also made them class methods in order to more easily deploy them through a background thread.
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
